### PR TITLE
docs: rename title and add content to introduction page

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -4,5 +4,34 @@ slug: ./
 sidebar_position: 1
 ---
 
-Data modeling tool (DMT) is a tool for modeling and presentation of data models (based on blueprints). DMT consists of a user interface for creating blueprints and data models, as well as an API for storing, querying, retrieving and sharing data models and their blueprints.
+The Development Framework is a framework for standardizing and simplifying processes of building applications by automating mechanisms for data and process modeling, data storage, front-end development and analysis orchestration. 
 
+## Overview
+
+The framework consists of several services, tools, libraries, and applications to be used in the development of applications.
+
+### Services
+
+* [Data modeling storage service] is a service used for storing and querying blueprints and entities.
+* [Data modeling job API] is a service for scheduling and running jobs using blueprints.
+
+### Tools
+
+* [Data modeling CLI] is a command-line interface (CLI) that can be used to
+  * Import and export blueprints and entities to the [data modeling storage service].
+* [Create data modeling app] is used to create new data modelling apps with just one command!
+
+### Packages
+
+* [Data modeling core packages] contains published [libraries](/docs/category/libraries) like the core frontend package and UI plugins.
+
+### Applications
+
+* [Data modeling tool] is a web-based tool for modeling, searching, viewing data models that are based on blueprints.
+
+[Data modeling job API]: https://github.com/equinor/dm-job
+[data modeling CLI]: https://github.com/equinor/dm-cli
+[data modeling core packages]: https://github.com/equinor/dm-core-packages 
+[create data modeling app]: https://github.com/equinor/create-dm-app
+[data modeling tool]: https://github.com/equinor/dm-app-dmt
+[data modeling storage service]: https://github.com/equinor/data-modelling-storage-service

--- a/docs/docs/libraries/_category_.yaml
+++ b/docs/docs/libraries/_category_.yaml
@@ -1,3 +1,6 @@
 label: 'Libraries'
 position: 5
-collapsed: false
+collapsed: true
+link:
+  type: generated-index
+  description: List of available libraries

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -32,8 +32,8 @@ function excludeJS(modulePath) {
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-    title: 'Data Modelling Docs',
-    tagline: 'An application for modelling, searching, and viewing domain models based on blueprints.',
+    title: 'Development Framework Docs',
+    tagline: 'The framework concists of a collection of libraries, tools and services that can be used to accelerate the building process and maintaince of applications and domain models based on blueprints.',
     url: 'https://data-modelling-tool.app.radix.equinor.com/',
     baseUrl: '/dm-docs/',
     onBrokenLinks: 'throw',
@@ -126,7 +126,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
         ({
             navbar: {
-                title: 'Data Modelling Tool',
+                title: 'Development Framework',
                 //logo: {
                 //    alt: 'My Site Logo',
                 //    src: 'img/logo.svg',


### PR DESCRIPTION
## What does this pull request change?

* Rename from "Data Modelling Tool" to "Development Framework" and adds a short introduction (overview) of the different repositories  

## Why is this pull request needed?

* Add more content to the docs

## Issues related to this change

