### PR TITLE
docs: add need to run create-lookup command

### DIFF
--- a/docs/docs/concepts/plugins.md
+++ b/docs/docs/concepts/plugins.md
@@ -3,21 +3,14 @@ title: Plugins
 sidebar_position: 3
 ---
 
-Add functionality and customize your applications using custom plugins.
+Add functionality and customize your apps using plugins.
 
-Custom plugins are Node.js packages that implement the DMT APIs (interfaces).
-
-There will be many types of custom plugins, but for now we support only UI plugins.
-
+Apps is designed to be extensible, and one of the best ways to add functionality to apps is through the plugin system.
 
 ## What is a Plugin?
 
-All plugins should be placed under the /custom-plugins folder.
+There will be many types of custom plugins, but for now we support only UI plugins.
 
-Custom plugins are Node.js packages that implement DMT APIs (interfaces). For larger, more complex custom applications, plugins let you modularize your site customizations into site-specific functionality.
+### What is a UI plugin?
 
-One of the best ways to add functionality to DMT applications is through the plugin system. DMT applications is designed to be extensible, which means plugins are able to extend and modify just about everything DMT does.
-
-Of the many possibilities, plugins can:
-
-* Show custom display for certain documents
+Of the many possibilities, but a UI plugins can be to show custom display for certain blueprints.

--- a/docs/docs/guides/application-development.md
+++ b/docs/docs/guides/application-development.md
@@ -94,36 +94,6 @@ URLs to external services are defined by environment variables in the start and 
 
 ## Extending the app
 
-### Adding a UI plugin
+Add functionality and customize your apps using [plugins](./../concepts/plugins.md) and [recipes](./../concepts/recipes.md).
 
-An example plugin is located at `/src/plugins/demo-app`.
-The requirements for a plugin is to have a `index[.js|.ts|.tsx|.jsx]` which exports a list of plugins, for example:
-
-```tsx
-import { EPluginType } from '@development-framework/dm-core'
-
-import App from './App'
-
-export const plugins: any = [
-  {
-    pluginName: 'demoApp',
-    pluginType: EPluginType.PAGE,
-    component: App,
-  }
-]
-```
-
-With that done, you must explicitly set which plugins to import into the project. This is done in the `src/plugins.js` file. Which will then look like this:
-
-```js
-const plugins = [
-    import("./plugins/demo-app"),
-]
-
-export default plugins
-
-```
-
-### Adding a job handler
-
-To add a job handler, follow the guide at [dm-job](https://github.com/equinor/dm-job#job-handler-plugins).
+See [plugin development](./plugin-development.md) for creating and adding new plugins.


### PR DESCRIPTION
## What does this pull request change?

* Adds `UI recipes` section in the application development page

## Why is this pull request needed?

* Explains where UI recipes links are located and how to run the create-lookup command

## Issues related to this change

