### PR TITLE
fix: make json less strict

### DIFF
--- a/docs/copy_config.py
+++ b/docs/copy_config.py
@@ -28,27 +28,39 @@ def create_code_blocks_section(example_config):
     child_blueprints = ""
     if "childBlueprints" in example_config:
         for child_blueprint in example_config["childBlueprints"]:
-            child_blueprints += create_json_code_block(child_blueprint["name"], "blueprint", child_blueprint)
+            child_blueprints += create_json_code_block(child_blueprint.get("name", "blueprint"), "blueprint", child_blueprint)
 
-    code_block = dedent(f"""
-{create_json_code_block(example_config["recipe"]["name"], "recipe", example_config["recipe"])}
-{create_json_code_block(example_config["blueprint"]["name"], "blueprint", example_config["blueprint"])}
-{child_blueprints}
-{create_json_code_block(example_config["entityFilePrefix"], "entity", example_config["entity"])}
-""")
+    recipe = example_config.get("recipe", {})
+    blueprint = example_config.get("blueprint", {})
+    entity = example_config.get("entity", {})
+    entity_prefix = example_config.get("entityFilePrefix", "entity")
+
+    sections = []
+    if recipe:
+        sections.append(create_json_code_block(recipe.get("name", "recipe"), "recipe", recipe))
+    if blueprint:
+        sections.append(create_json_code_block(blueprint.get("name", "blueprint"), "blueprint", blueprint))
+    if child_blueprints:
+        sections.append(child_blueprints)
+    if entity:
+        sections.append(create_json_code_block(entity_prefix, "entity", entity))
+
+    code_block = "\n".join(sections)
     return code_block
 
 
 def create_info_block(example_config):
     """Create text block for description and/or note"""
     additional_info = ""
-    if example_config["description"]:
-        additional_info += example_config["description"]
-    if example_config["note"]:
+    description = example_config.get("description", "")
+    note = example_config.get("note", "")
+    if description:
+        additional_info += description
+    if note:
         additional_info += dedent(f"""
         :::note
         
-        {example_config["note"]}
+        {note}
         
         :::
         """)
@@ -57,7 +69,7 @@ def create_info_block(example_config):
 
 def create_demo_block(example_config):
     """Create block for demo example or note if not available"""
-    if example_config["showDemo"]:
+    if example_config.get("showDemo", False):
         return f"<PluginExample exampleConfig={{{json.dumps(example_config)}}} />"
     return dedent("""
         :::note
@@ -87,10 +99,16 @@ def create_example_files(plugin, destination_folder_path, base_source_path) -> N
             try:
                 with open(example_file_source_path, 'r', encoding="utf-8") as example_source_file:
                     example_config = json.load(example_source_file)
+
+                expected_keys = {"title", "description", "note", "showDemo", "recipe", "blueprint", "entity", "entityFilePrefix"}
+                missing_keys = expected_keys - example_config.keys()
+                if missing_keys:
+                    logger.warning(f"Example config '{example_file_source_path}' is missing keys: {missing_keys}")
+
                 with open(f'{folder_path}/{example}.mdx', 'a+', encoding="utf-8") as example_destination_file:
                     plugin_demo = dedent(f"""\
 ---
-title: {example_config['title']}
+title: {example_config.get('title', example)}
 ---
 
 import {{ PluginExample }} from '@site/src/components'


### PR DESCRIPTION
This pull request refactors the handling of example configuration files in `docs/copy_config.py` to make the code more robust against missing keys and improve error handling. The changes ensure that missing configuration fields are handled gracefully and add logging to help identify incomplete example configs.

**Error handling and robustness improvements:**

* Updated `create_code_blocks_section`, `create_info_block`, and `create_demo_block` to use `.get()` instead of direct key access, preventing `KeyError` exceptions if a field is missing. [[1]](diffhunk://#diff-9067874ca8ad60d9d3068ebc39a46d7fc9285a84bc8916a0d79d04f1792cc693L31-R63) [[2]](diffhunk://#diff-9067874ca8ad60d9d3068ebc39a46d7fc9285a84bc8916a0d79d04f1792cc693L60-R72)
* Added logic to check for missing expected keys in example configs, and log a warning if any are absent.

**Code maintainability:**

* Refactored code block and info block generation to use default values and conditional checks, making the code easier to maintain and extend. [[1]](diffhunk://#diff-9067874ca8ad60d9d3068ebc39a46d7fc9285a84bc8916a0d79d04f1792cc693L31-R63) [[2]](diffhunk://#diff-9067874ca8ad60d9d3068ebc39a46d7fc9285a84bc8916a0d79d04f1792cc693L60-R72) [[3]](diffhunk://#diff-9067874ca8ad60d9d3068ebc39a46d7fc9285a84bc8916a0d79d04f1792cc693R102-R111)