### PR TITLE
fix: add url polyfill

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -106,6 +106,7 @@ const config = {
 					resolve: {
 						fallback: {
 							path: require.resolve("path-browserify"),
+							url: require.resolve("url/"),
 							fs: false,
 						},
 						symlinks: true,

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -38,7 +38,8 @@
         "react-notifications": "^1.7.4",
         "react-router-dom": "^6.22.3",
         "styled-components": "^6.3.11",
-        "swizzle": "1.1.0"
+        "swizzle": "1.1.0",
+        "url": "^0.11.4"
       },
       "devDependencies": {
         "@babel/preset-flow": "^7.27.1",
@@ -24164,6 +24165,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/url-loader": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -24239,6 +24253,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/use-editable": {
       "version": "2.3.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -49,7 +49,8 @@
     "react-notifications": "^1.7.4",
     "react-router-dom": "^6.22.3",
     "styled-components": "^6.3.11",
-    "swizzle": "1.1.0"
+    "swizzle": "1.1.0",
+    "url": "^0.11.4"
   },
   "devDependencies": {
     "@babel/preset-flow": "^7.27.1",


### PR DESCRIPTION
This pull request adds the `url` package as a dependency to the documentation site and updates the Webpack configuration to use it as a fallback for browser environments. These changes ensure that modules depending on Node's `url` functionality will work correctly in the browser build.

Dependency additions and updates:

* Added `url` version `^0.11.4` to the `dependencies` section of both `docs/package.json` and `docs/package-lock.json`, ensuring it is available for use in the project. [[1]](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56L52-R53) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0L41-R42)
* Updated `docs/package-lock.json` to include the full metadata for the new `url` package and its direct dependencies, such as `punycode` and `qs`. [[1]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R24168-R24180) [[2]](diffhunk://#diff-aced7929d69b779cb242efe99440d62fdf10cc24bb6ac6a958cb0870be3d41a0R24257-R24262)

Build configuration changes:

* Modified the Webpack fallback configuration in `docs/docusaurus.config.js` to resolve the `url` module using the newly added dependency, enabling browser compatibility for packages that require Node's `url`.