### PR TITLE
fix: wrap query client

### DIFF
--- a/docs/src/components/PluginExample.tsx
+++ b/docs/src/components/PluginExample.tsx
@@ -5,9 +5,12 @@ import {
 } from '@development-framework/dm-core'
 import DMTPlugins from '@development-framework/dm-core-plugins'
 import BrowserOnly from '@docusaurus/BrowserOnly'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type React from 'react'
 import { Suspense } from 'react'
 import styled from 'styled-components'
+
+const queryClient = new QueryClient()
 
 type TPluginExample = {
   exampleConfig: {
@@ -104,10 +107,12 @@ export const PluginPreview = ({ exampleConfig }: TPluginExample) => {
   }
 
   return (
-    /* @ts-expect-error*/
-    <ApplicationContext.Provider value={{ dmssAPI, getUiPlugin }}>
-      <UIPlugin type="" idReference="example" config={recipe?.config} />
-    </ApplicationContext.Provider>
+    <QueryClientProvider client={queryClient}>
+      {/* @ts-expect-error*/}
+      <ApplicationContext.Provider value={{ dmssAPI, getUiPlugin }}>
+        <UIPlugin type="" idReference="example" config={recipe?.config} />
+      </ApplicationContext.Provider>
+    </QueryClientProvider>
   )
 }
 


### PR DESCRIPTION
This pull request updates the `PluginExample` component to support React Query for improved data fetching and caching. The main change is the addition of a `QueryClientProvider` around the plugin preview, which enables usage of React Query features in child components.

Integration of React Query:

* Added imports for `QueryClient` and `QueryClientProvider` from `@tanstack/react-query` and initialized a `queryClient` instance in `docs/src/components/PluginExample.tsx`.
* Wrapped the `ApplicationContext.Provider` and its children in a `QueryClientProvider` within the `PluginPreview` component to enable React Query context for plugin previews.