### PR TITLE
fix: query client root

### DIFF
--- a/docs/src/components/PluginExample.tsx
+++ b/docs/src/components/PluginExample.tsx
@@ -5,12 +5,9 @@ import {
 } from '@development-framework/dm-core'
 import DMTPlugins from '@development-framework/dm-core-plugins'
 import BrowserOnly from '@docusaurus/BrowserOnly'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type React from 'react'
 import { Suspense } from 'react'
 import styled from 'styled-components'
-
-const queryClient = new QueryClient()
 
 type TPluginExample = {
   exampleConfig: {
@@ -107,12 +104,10 @@ export const PluginPreview = ({ exampleConfig }: TPluginExample) => {
   }
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {/* @ts-expect-error*/}
-      <ApplicationContext.Provider value={{ dmssAPI, getUiPlugin }}>
-        <UIPlugin type="" idReference="example" config={recipe?.config} />
-      </ApplicationContext.Provider>
-    </QueryClientProvider>
+    // @ts-expect-error
+    <ApplicationContext.Provider value={{ dmssAPI, getUiPlugin }}>
+      <UIPlugin type="" idReference="example" config={recipe?.config} />
+    </ApplicationContext.Provider>
   )
 }
 

--- a/docs/src/theme/Root.tsx
+++ b/docs/src/theme/Root.tsx
@@ -1,0 +1,10 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type React from 'react'
+
+const queryClient = new QueryClient()
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}


### PR DESCRIPTION
This pull request refactors how the React Query client is provided to components in the documentation site. The main change is moving the `QueryClientProvider` from the `PluginExample` component to a new top-level `Root` component, ensuring that the React Query context is available application-wide rather than just within the plugin example.

Context provider refactoring:

* Moved the `QueryClientProvider` setup from `PluginExample.tsx` to a new `Root.tsx` component, allowing all children to access the React Query context. (`docs/src/components/PluginExample.tsx`, `docs/src/theme/Root.tsx`) [[1]](diffhunk://#diff-b84f437c22f501371ba120f9a6bbd9056f8a84f2cd1fe18ec79b54632638fb61L8-L14) [[2]](diffhunk://#diff-b84f437c22f501371ba120f9a6bbd9056f8a84f2cd1fe18ec79b54632638fb61L110-L115) [[3]](diffhunk://#diff-94507a2ab1be6f67d40b27975b61af4e808f8b4f415d57dd9732b750f1360d04R1-R10)

Code cleanup:

* Removed the local instantiation of `QueryClient` and its provider from `PluginExample.tsx`, simplifying the component and its usage. (`docs/src/components/PluginExample.tsx`) [[1]](diffhunk://#diff-b84f437c22f501371ba120f9a6bbd9056f8a84f2cd1fe18ec79b54632638fb61L8-L14) [[2]](diffhunk://#diff-b84f437c22f501371ba120f9a6bbd9056f8a84f2cd1fe18ec79b54632638fb61L110-L115)