### PR TITLE
fix: query client resolved

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -96,6 +96,10 @@ const config = {
 					__dirname,
 					"./node_modules/react-dom",
 				);
+				config.resolve.alias["@tanstack/react-query"] = _resolve(
+					__dirname,
+					"./node_modules/@tanstack/react-query",
+				);
 				config.plugins.push(
 					new ProvidePlugin({
 						process: "process/browser.js",

--- a/docs/src/components/PluginExample.tsx
+++ b/docs/src/components/PluginExample.tsx
@@ -65,7 +65,11 @@ export const PluginPreview = ({ exampleConfig }: TPluginExample) => {
   const { entity, blueprint, recipe, scope } = exampleConfig
 
   const dmssAPI = {
+    // Small delay ensures useBlueprint (useEffect+setState) resolves before
+    // useDocument (react-query), preventing a race condition where dimensions
+    // default to "*,*" (multi-dimensional) while data is actually 1D.
     documentGet: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50))
       return { data: scope ? entity[scope] : entity }
     },
     blueprintGet: async () => ({ data: { blueprint } }),


### PR DESCRIPTION
This pull request introduces an improvement to the plugin preview system in the documentation site, specifically addressing a race condition in the data fetching logic and updating the module resolution configuration to support `@tanstack/react-query`. These changes help ensure more reliable component behavior and compatibility with the latest dependencies.

**Dependency and configuration updates:**

* Added an alias for `@tanstack/react-query` in the webpack configuration within `docs/docusaurus.config.js` to ensure the correct module is resolved during build and development.

**Bug fix and reliability improvements:**

* Introduced a small delay in the `documentGet` function of the `dmssAPI` object in `docs/src/components/PluginExample.tsx` to prevent a race condition between React hooks (`useBlueprint` and `useDocument`), ensuring dimension defaults are set correctly before data is fetched.