### PR TITLE
fix: skip test files

### DIFF
--- a/docs/tsconfig.typedoc.json
+++ b/docs/tsconfig.typedoc.json
@@ -1,6 +1,16 @@
 {
   "extends": "./node_modules/@development-framework/dm-core/tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false
-  }
+    "noImplicitAny": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "node_modules/@development-framework/dm-core/src"
+  ],
+  "exclude": [
+    "node_modules/@development-framework/dm-core/src/**/*.test.ts",
+    "node_modules/@development-framework/dm-core/src/**/*.test.tsx",
+    "node_modules/@development-framework/dm-core/src/**/*.spec.ts",
+    "node_modules/@development-framework/dm-core/src/**/*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
This pull request updates the TypeScript configuration for Typedoc to improve documentation generation and type checking. The main changes are focused on including the relevant source files, excluding test files, and optimizing type checking.

Typedoc configuration improvements:

* Added the `skipLibCheck` option to the `compilerOptions` in `docs/tsconfig.typedoc.json` to speed up type checking by skipping library files.
* Updated the `include` section to ensure that only the source files from `@development-framework/dm-core` are included for documentation.
* Added an `exclude` section to prevent test and spec files from being processed by Typedoc, resulting in cleaner documentation.