### PR TITLE
chore: add github actions config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request adds configuration to enable Dependabot updates for GitHub Actions workflows. Dependabot will now automatically check for and propose updates to GitHub Actions dependencies on a weekly schedule.

* Dependabot configuration: Added a new entry for the `github-actions` package ecosystem in `.github/dependabot.yml`, scheduling weekly updates for workflow dependencies.