### PR TITLE
fix: show dm core packages version

### DIFF
--- a/docs/generate-typedocs.js
+++ b/docs/generate-typedocs.js
@@ -11,6 +11,12 @@ const mdxBaseDirectory = './docs/libraries'
 // Which component types should have a 'live preview' of the example code
 const codePreviewComponentTypes = ['Components']
 
+// All packages that should display their version in the sidebar
+const versionedPackages = [
+  '@development-framework/dm-core',
+  '@development-framework/dm-core-plugins',
+]
+
 // The libraries that should be documented
 const libraries = {
   '@development-framework/dm-core': {
@@ -136,13 +142,15 @@ function write_version_category(libraryName) {
 }
 
 async function main() {
+  // Write version labels for all packages in the sidebar
+  for (const pkg of versionedPackages) {
+    write_version_category(pkg)
+  }
+
   for (const library of Object.keys(libraries)) {
     console.log(`=== Generating docs for '${library}'...`)
     const entryPoints = libraries[library].entryPoints
     const tsConfig = libraries[library].tsConfig
-
-    // Write a _category_.yaml with the package version in the sidebar label
-    write_version_category(library)
 
     // Generate typedocs
     await generate_json(entryPoints, tsConfig).catch(console.error)


### PR DESCRIPTION
This pull request updates the documentation generation script to improve how version labels are displayed in the sidebar for select packages. The main change is to ensure that only specific packages show their version in the sidebar, rather than all documented libraries.

Documentation sidebar improvements:

* Added a `versionedPackages` array to `docs/generate-typedocs.js` to explicitly list which packages should display their version in the sidebar. (`[docs/generate-typedocs.jsR14-R19](diffhunk://#diff-ff7093d1ada4630e1257138fcf23b04c404d1cd6cae85a70d1aa0e4ba9243519R14-R19)`)
* Modified the main function to write version labels only for packages in `versionedPackages`, instead of for every library in the documentation. (`[docs/generate-typedocs.jsR145-L146](diffhunk://#diff-ff7093d1ada4630e1257138fcf23b04c404d1cd6cae85a70d1aa0e4ba9243519R145-L146)`)