### PR TITLE
ci: set workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,15 +32,7 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     uses: ./.github/workflows/tests.yml
@@ -14,6 +17,8 @@ jobs:
     needs: run-tests
     runs-on: ubuntu-latest
     name: Build and deploy docs to Github pages
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -9,6 +9,9 @@ on:
     tags-ignore:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   # Workflow call is used for called from another workflow
   workflow_call:
 
+permissions:
+  contents: read
+  
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to explicitly set permissions for improved security and clarity. The changes ensure that each workflow only requests the minimum permissions needed for its tasks, following GitHub best practices.

**Permissions configuration updates:**

* Added `contents: read` permission to the top-level of `.github/workflows/on-push-main.yml`, `.github/workflows/on-push.yml`, and `.github/workflows/tests.yml` to allow workflows to access repository contents. [[1]](diffhunk://#diff-11e4d91509ddb811ec2b547aafe595b4dac37e792aa94d13aed66ab0294348a5R9-R11) [[2]](diffhunk://#diff-1627952414787bd2f89d526459771a1f2c92a48d7309f7b4e307f81753eedb04R12-R14) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR7-R9)
* Added `contents: write` permission to the `Build and deploy docs to Github pages` job in `.github/workflows/on-push-main.yml` so it can publish documentation to GitHub Pages.
* Added `issues: write` and `pull-requests: write` permissions to `.github/workflows/stale.yml` to allow the workflow to mark issues and pull requests as stale.

**Simplification and cleanup:**

* Removed redundant and unnecessary permissions from the `jobs:` section of `.github/workflows/codeql.yml` to streamline the workflow configuration.